### PR TITLE
solving a problem where the success callback seems to be fired many t…

### DIFF
--- a/lib/digitalocean.droplets.js
+++ b/lib/digitalocean.droplets.js
@@ -18,14 +18,18 @@ Droplets.prototype.createQuery = function() {
 };
 
 function makeRequest(fn, uri, options, callback) {
+    var handler = function(result) {
+        if (result instanceof Error) {
+            callback(result);
+        } else {
+            callback(null, result);
+        }
+
+        this.removeListener('complete', handler);
+    };
+
     fn(uri, options)
-        .on('complete', function(result) {
-            if (result instanceof Error) {
-                callback(result);
-            } else {
-                callback(null, result);
-            }
-        });
+        .on('complete', handler);
 }
 
 function makeRequestJson(fn, uri, data, options, callback) {


### PR DESCRIPTION
…imes if you call the method more then 1 time. Example: when I call 'listDroplets' in two different moments. The callbacks seems to be accumulating.

I was trying to check the droplets statuses in regular periods and the callbacks seems to be firing many times. This fixed for this cases.
